### PR TITLE
Fix connection timeout (works once then stops working)

### DIFF
--- a/custom_components/comelit_intercom/comelit_client.py
+++ b/custom_components/comelit_intercom/comelit_client.py
@@ -85,6 +85,10 @@ class IconaBridgeClient:
                 asyncio.open_connection(self.host, self.port), timeout=10.0
             )
             self.logger.info("Connected")
+            # Ensure we start with a clean channel state for every new socket
+            # session. If a previous close operation failed, we don't want to
+            # reuse stale channel metadata with the new connection.
+            self.open_channels.clear()
 
         except TimeoutError as e:
             self.logger.error(f"Connection timeout to {self.host}:{self.port}")
@@ -139,6 +143,8 @@ class IconaBridgeClient:
             self.writer.close()
             await self.writer.wait_closed()
             self.logger.info("Connection closed")
+        # Drop any cached channel state so a future connection starts fresh.
+        self.open_channels.clear()
 
     def _create_header(self, body_length: int, request_id: int = 0) -> bytes:
         """Create 8-byte message header
@@ -326,11 +332,27 @@ class IconaBridgeClient:
         )
         await self._write_packet(packet)
 
-        response = await self._read_response()
+        try:
+            response = await self._read_response()
+        except Exception as err:  # pragma: no cover - defensive cleanup
+            self.logger.debug(
+                "Failed to read close response for %s channel: %s",
+                channel_data.channel,
+                err,
+            )
+            response = None
+
+        # Always forget the channel locally so we never reuse stale metadata.
+        self.open_channels.pop(channel_data.channel, None)
+
         if response and response["type"] == "binary":
-            del self.open_channels[channel_data.channel]
             self.logger.debug(f"Closed channel {channel_data.channel}")
             return True
+
+        self.logger.debug(
+            "Channel %s closed locally without explicit acknowledgment",
+            channel_data.channel,
+        )
         return False
 
     async def authenticate(self, token: str) -> int:
@@ -534,6 +556,13 @@ class IconaBridgeClient:
         # Don't wait for final responses - the door actuator triggers immediately
         # and the device may not send acknowledgments
         self.logger.info(f"Door '{door_item.get('name', 'Unknown')}' open command sent")
+
+        # Always close the CTPP channel so subsequent connections don't get stuck
+        # waiting for the previous session to timeout on the device.
+        try:
+            await self._close_channel(channel)
+        except Exception as err:  # pragma: no cover - best effort cleanup
+            self.logger.debug("Failed to close CTPP channel cleanly: %s", err)
 
 
 # High-level convenience functions

--- a/custom_components/comelit_intercom/comelit_client.py
+++ b/custom_components/comelit_intercom/comelit_client.py
@@ -535,6 +535,13 @@ class IconaBridgeClient:
         # and the device may not send acknowledgments
         self.logger.info(f"Door '{door_item.get('name', 'Unknown')}' open command sent")
 
+        # Always close the CTPP channel so subsequent connections don't get stuck
+        # waiting for the previous session to timeout on the device.
+        try:
+            await self._close_channel(channel)
+        except Exception as err:  # pragma: no cover - best effort cleanup
+            self.logger.debug("Failed to close CTPP channel cleanly: %s", err)
+
 
 # High-level convenience functions
 async def list_doors(host: str, token: str) -> list[dict[str, Any]]:


### PR DESCRIPTION

Hi - I spent some time debugging the error where the commands worked once and then timed out.  I believe the third change below is the key change.  I have been running this for almost a week with perfect execution.  For me, it always worked again when I disabled and reenabled the integration so cleaning up the socket seemed to be the solution.

Specifically: 
-Ensure CTPP control channels are closed and state cleared after each door command to prevent lingering channel metadata
-Clear cached channel data whenever connections are opened or closed so subsequent sessions do not reuse stale state
-Create a new `IconaBridgeClient` instance for every coordinator refresh so each poll starts from a fresh socket session